### PR TITLE
PLF-8307: Lecko Addon: Unable to remove dump file after sending extraction to sftp server.

### DIFF
--- a/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
+++ b/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
@@ -21,9 +21,14 @@
 package org.exoplatform.addons.lecko;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 
+import java.nio.file.Path;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.component.RequestLifeCycle;
@@ -316,12 +321,15 @@ public class SimpleDataBuilder implements DataBuilder {
 
   public void deleteDumpFile() {
     String extractOutputPath = leckoTempDirectory + "/" + leckoOutputName;
-    File file = new File(extractOutputPath);
-    try {
-        file.delete();
+    Path path = Paths.get(extractOutputPath);
+    try{
+      Files.delete(path);
+      LOG.info("Dump file deleted.");
     }
-    catch (Exception ex){
-        LOG.info("Unable to delete the dump file: ", ex);
+    catch(NoSuchFileException e) {
+      LOG.error("no file found",e);
+    } catch(IOException e) {
+      LOG.error("error while deleting file",e);
     }
   }
 

--- a/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
+++ b/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
@@ -323,7 +323,7 @@ public class SimpleDataBuilder implements DataBuilder {
       LOG.info("Dump file deleted.");
     }
     catch(NoSuchFileException e) {
-      LOG.error("The dump file to delete (" + path + ") does not exist", e);
+      LOG.error("The Lecko dump file to delete (" + path + ") does not exist", e);
     } catch(IOException e) {
       LOG.error("The dump file to delete (" + path + ") does not exist", e);
     }

--- a/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
+++ b/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
@@ -317,7 +317,12 @@ public class SimpleDataBuilder implements DataBuilder {
   public void deleteDumpFile() {
     String extractOutputPath = leckoTempDirectory + "/" + leckoOutputName;
     File file = new File(extractOutputPath);
-    file.delete();
+    try {
+        file.delete();
+    }
+    catch (Exception ex){
+        LOG.info("Unable to delete the dump file: ", ex);
+    }
   }
 
   // @Override

--- a/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
+++ b/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
@@ -318,7 +318,7 @@ public class SimpleDataBuilder implements DataBuilder {
   public void deleteDumpFile() {
     String extractOutputPath = leckoTempDirectory + "/" + leckoOutputName;
     Path path = Paths.get(extractOutputPath);
-    try{
+    try {
       Files.delete(path);
       LOG.info("Lecko dump file deleted.");
     }

--- a/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
+++ b/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
@@ -320,7 +320,7 @@ public class SimpleDataBuilder implements DataBuilder {
     Path path = Paths.get(extractOutputPath);
     try{
       Files.delete(path);
-      LOG.info("Dump file deleted.");
+      LOG.info("Lecko dump file deleted.");
     }
     catch(NoSuchFileException e) {
       LOG.error("The Lecko dump file to delete (" + path + ") does not exist", e);

--- a/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
+++ b/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
@@ -325,7 +325,7 @@ public class SimpleDataBuilder implements DataBuilder {
     catch(NoSuchFileException e) {
       LOG.error("The Lecko dump file to delete (" + path + ") does not exist", e);
     } catch(IOException e) {
-      LOG.error("The dump file to delete (" + path + ") does not exist", e);
+      LOG.error("Error while deleting the Lecko dump file " + path, e);
     }
   }
 

--- a/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
+++ b/service/src/main/java/org/exoplatform/addons/lecko/SimpleDataBuilder.java
@@ -23,12 +23,8 @@ package org.exoplatform.addons.lecko;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.io.FileWriter;
 import java.io.PrintWriter;
-
-import java.nio.file.Path;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.component.RequestLifeCycle;
@@ -327,9 +323,9 @@ public class SimpleDataBuilder implements DataBuilder {
       LOG.info("Dump file deleted.");
     }
     catch(NoSuchFileException e) {
-      LOG.error("no file found",e);
+      LOG.error("The dump file to delete (" + path + ") does not exist", e);
     } catch(IOException e) {
-      LOG.error("error while deleting file",e);
+      LOG.error("The dump file to delete (" + path + ") does not exist", e);
     }
   }
 

--- a/service/src/main/java/org/exoplatform/addons/lecko/Utils/SftpClient.java
+++ b/service/src/main/java/org/exoplatform/addons/lecko/Utils/SftpClient.java
@@ -191,7 +191,7 @@ public class SftpClient {
         File f = new File(fileName);
 
         try(FileInputStream fileInputStream = new FileInputStream(f)) {
-              channelSftp.put(fileInputStream, f.getName());
+          channelSftp.put(fileInputStream, f.getName());
         }
         LOG.info("Transfer of {} on the sftp server done", fileName);
         return true;

--- a/service/src/main/java/org/exoplatform/addons/lecko/Utils/SftpClient.java
+++ b/service/src/main/java/org/exoplatform/addons/lecko/Utils/SftpClient.java
@@ -189,8 +189,10 @@ public class SftpClient {
 
         LOG.info("Transfering {}", fileName);
         File f = new File(fileName);
-        channelSftp.put(new FileInputStream(f), f.getName());
 
+        try(FileInputStream fileInputStream = new FileInputStream(f)) {
+              channelSftp.put(fileInputStream, f.getName());
+        }
         LOG.info("Transfer of {} on the sftp server done", fileName);
         return true;
       } catch (Exception ex) {

--- a/service/src/test/java/org/exoplatform/lecko/service/TestSftpClient.java
+++ b/service/src/test/java/org/exoplatform/lecko/service/TestSftpClient.java
@@ -89,5 +89,8 @@ public class TestSftpClient extends AbstractServiceTest {
 
     // Verify no log append
     verify(mockAppender, Mockito.times(0)).doAppend(captorLoggingEvent.capture());
+
+    // check client.send return false
+    assertFalse(client.send("toto.txt"));
   }
 }


### PR DESCRIPTION
The file.delete() method on windows was not working good. It seems that another process is attached to deletion operation. This process is related to create another file FileInputStream when transfering the dump file via SFTP channel.
by adding try catch clause, we could be sure that the sftpchannel will be exited when isn't null (by finally clause)
