### PR TITLE
PLF-8437 : Duplication sub-comments on lecko extract

### DIFF
--- a/service/src/main/java/org/exoplatform/addons/lecko/SocialActivity.java
+++ b/service/src/main/java/org/exoplatform/addons/lecko/SocialActivity.java
@@ -65,7 +65,7 @@ abstract class SocialActivity {
     int offsetComments = DEFAULT_OFFSET;
     boolean hasNextComments = true;
 
-    RealtimeListAccess<ExoSocialActivity> commentsWithListAccess = activityManager.getCommentsWithListAccess(activity,true);
+    RealtimeListAccess<ExoSocialActivity> commentsWithListAccess = activityManager.getCommentsWithListAccess(activity,false);
     int commentCountToTreat = commentsWithListAccess.getSize();
     int commentTreated = 0;
     while (hasNextComments) {

--- a/service/src/test/java/org/exoplatform/lecko/service/TestUserActivityWithCommentAComment.java
+++ b/service/src/test/java/org/exoplatform/lecko/service/TestUserActivityWithCommentAComment.java
@@ -43,12 +43,9 @@ public class TestUserActivityWithCommentAComment extends AbstractServiceTest {
 //    jobStatusService = (JobStatusService) getContainer().getComponentInstanceOfType(JobStatusService.class);
 
     // john post activity
-
     Identity johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", true);
     Identity maryIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "mary", true);
     Identity jackIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "demo", true);
-
-
 
     ExoSocialActivity activity = new ExoSocialActivityImpl();
     activity.setTitle("My Activity");
@@ -68,10 +65,6 @@ public class TestUserActivityWithCommentAComment extends AbstractServiceTest {
     commentJack.setUserId(jackIdentity.getId());
     commentJack.setParentCommentId(comment.getId());
     activityManager.saveComment(activity, commentJack);
-
-
-
-
   }
 
   public void testBuildUserExportWithCommentAComment() throws Exception {
@@ -91,6 +84,9 @@ public class TestUserActivityWithCommentAComment extends AbstractServiceTest {
 
     String ls = System.getProperty("line.separator");
     String[] lines = fileContent.split(ls);
+
+    // Assert that the file contain 9 lines.
+    assertEquals(9, lines.length);
 
     // 1;DEFAULT_ACTIVITY;2017-03-30T10:12:36.743+02:00;user;;
     // Discussions;

--- a/service/src/test/java/org/exoplatform/lecko/test/AbstractServiceTest.java
+++ b/service/src/test/java/org/exoplatform/lecko/test/AbstractServiceTest.java
@@ -111,9 +111,17 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
   @Override
   protected void tearDown() throws Exception {
 
+    resetAllActivities();
 
     //
     end();
+  }
+
+  private void resetAllActivities() throws Exception {
+    List<Identity> identities = identityManager.getIdentities(OrganizationIdentityProvider.NAME);
+    for (Identity identity: identities) {
+      activityManager.getActivities(identity).forEach(activityManager::deleteActivity);
+    }
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
# FIX - Duplicates sub comments activity on lecko extracts

Fix duplicates lines during a Lecko extraction.
The tests corresponding to the extraction of comments have been updated.